### PR TITLE
chromium: update libxkbcommon DEPENDS

### DIFF
--- a/recipes-browser/chromium/chromium.inc
+++ b/recipes-browser/chromium/chromium.inc
@@ -1,5 +1,5 @@
 LICENSE = "BSD"
-DEPENDS = "xz-native pciutils pulseaudio cairo nss zlib-native cups ninja-native gconf libexif pango libdrm virtual/egl"
+DEPENDS = "xz-native pciutils pulseaudio cairo nss zlib-native cups ninja-native gconf libexif pango libdrm virtual/egl libxkbcommon"
 RDEPENDS_${PN} += "pango cairo fontconfig pciutils pulseaudio freetype fontconfig-utils"
 COMPATIBLE_MACHINE = "(-)"
 COMPATIBLE_MACHINE_x86 = "(.*)"

--- a/recipes-browser/chromium/chromium_45.0.2454.85.bb
+++ b/recipes-browser/chromium/chromium_45.0.2454.85.bb
@@ -193,7 +193,7 @@ GYP_DEFINES += "${ARMFPABI} release_extra_cflags='-Wno-error=unused-local-typede
 # a few times in the past already; making them variables makes it easier to handle that
 CHROMIUM_X11_DEPENDS = "xextproto gtk+ libxi libxss"
 CHROMIUM_X11_GYP_DEFINES = ""
-CHROMIUM_WAYLAND_DEPENDS = "wayland libxkbcommon"
+CHROMIUM_WAYLAND_DEPENDS = "wayland"
 CHROMIUM_WAYLAND_GYP_DEFINES = "use_ash=1 use_aura=1 chromeos=0 use_ozone=1"
 
 python() {

--- a/recipes-browser/chromium/chromium_47.0.2510.0.bb
+++ b/recipes-browser/chromium/chromium_47.0.2510.0.bb
@@ -164,7 +164,7 @@ GYP_DEFINES += "${ARMFPABI} release_extra_cflags='-Wno-error=unused-local-typede
 # a few times in the past already; making them variables makes it easier to handle that
 CHROMIUM_X11_DEPENDS = "xextproto gtk+ libxi libxss"
 CHROMIUM_X11_GYP_DEFINES = ""
-CHROMIUM_WAYLAND_DEPENDS = "wayland libxkbcommon"
+CHROMIUM_WAYLAND_DEPENDS = "wayland"
 CHROMIUM_WAYLAND_GYP_DEFINES = "use_ash=1 use_aura=1 chromeos=0 use_ozone=1"
 
 python() {


### PR DESCRIPTION
The gypi file for this recipe explicitly requests that xkbcommon be used. This
dependency exists for both x11 and wayland builds. Therefore move this
requirement up into the common include file for all builds.

Signed-off-by: Trevor Woerner twoerner@gmail.com
