### PR TITLE
chromium: fix the recipes to work with bitbake 1.30

### DIFF
--- a/recipes-browser/chromium/chromium_45.0.2454.85.bb
+++ b/recipes-browser/chromium/chromium_45.0.2454.85.bb
@@ -150,7 +150,7 @@ python add_ozone_wayland_patches() {
         d.appendVar('SRC_URI', ' file://' + upstream_patch)
     # then, add the extra patches to SRC_URI order matters;
     # extra patches may depend on the base ozone-wayland ones
-    d.appendVar('SRC_URI', ' ' + d.getVar('OZONE_WAYLAND_EXTRA_PATCHES'))
+    d.appendVar('SRC_URI', ' ' + d.getVar('OZONE_WAYLAND_EXTRA_PATCHES', False))
     # For ARM architecture we need to reverse one of the VAAPI patches.
     # This is patch should be removed once the upstream wayland-ozone
     # gets a fix for this.

--- a/recipes-browser/chromium/chromium_47.0.2510.0.bb
+++ b/recipes-browser/chromium/chromium_47.0.2510.0.bb
@@ -135,7 +135,7 @@ python add_ozone_wayland_patches() {
         d.appendVar('SRC_URI', ' file://' + upstream_patch)
     # then, add the extra patches to SRC_URI order matters;
     # extra patches may depend on the base ozone-wayland ones
-    d.appendVar('SRC_URI', ' ' + d.getVar('OZONE_WAYLAND_EXTRA_PATCHES'))
+    d.appendVar('SRC_URI', ' ' + d.getVar('OZONE_WAYLAND_EXTRA_PATCHES', False))
 }
 
 EXTRA_OEGYP =	" \


### PR DESCRIPTION
Account for getVar API change:
http://cgit.openembedded.org/bitbake/commit/?h=1.30&id=fab717d303df0bcef737661f6917f275f35215a4

Signed-off-by: Andrey Konovalov andrey.konovalov@linaro.org
