### PR TITLE
chromium: Remove dependency on Linux 4.5

### DIFF
--- a/recipes-browser/chromium/chromium/chromium-45/Do-not-depend-on-Linux-4.5.patch
+++ b/recipes-browser/chromium/chromium/chromium-45/Do-not-depend-on-Linux-4.5.patch
@@ -1,0 +1,32 @@
+From 6e5f0405559780ee3c45825f065e216bf472c262 Mon Sep 17 00:00:00 2001
+From: Allan Sandfeld Jensen <allan.jensen@theqtcompany.com>
+Date: Tue, 9 Aug 2016 16:21:29 +0200
+Subject: [PATCH] Do not depend on Linux 4.5
+
+Avoid using MADV_FREE that was only recently added to Linux. It will fail when
+run on older Linux kernels.
+
+Change-Id: I9b0369fb31402f088b2327c12f70dd39f5e4c8c0
+Reviewed-by: Peter Varga <pvarga@inf.u-szeged.hu>
+---
+ third_party/WebKit/Source/wtf/PageAllocator.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/third_party/WebKit/Source/wtf/PageAllocator.cpp b/third_party/WebKit/Source/wtf/PageAllocator.cpp
+index 12c9a7b..1639013 100644
+--- a/third_party/WebKit/Source/wtf/PageAllocator.cpp
++++ b/third_party/WebKit/Source/wtf/PageAllocator.cpp
+@@ -40,6 +40,11 @@
+
+ #include <sys/mman.h>
+
++#if OS(LINUX) && defined(MADV_FREE)
++// Added in Linux 4.5, but we don't want to depend on 4.5 at runtime
++#undef MADV_FREE
++#endif
++
+ #ifndef MADV_FREE
+ #define MADV_FREE MADV_DONTNEED
+ #endif
+--
+2.9.3

--- a/recipes-browser/chromium/chromium_45.0.2454.85.bb
+++ b/recipes-browser/chromium/chromium_45.0.2454.85.bb
@@ -100,6 +100,7 @@ SRC_URI += "\
         file://chromium-45/0011-Replace-readdir_r-with-readdir.patch \
 	file://chromium-45/remove-Werror.patch \
         file://chromium-45/Remove-base-internal-InotifyReaders-destructor.patch \
+        file://chromium-45/Do-not-depend-on-Linux-4.5.patch \
         file://chromium-45/Ozone-Fix-clang-build.patch \
 "
 


### PR DESCRIPTION
This fixes the builds using glibc >= 2.24 (the current LHG builds in particular)

From:
https://github.com/OSSystems/meta-browser/commit/fb4e542079958b6afde324a1e9bfdd695842aeeb