### PR TITLE
Remove zoltan GitHub

### DIFF
--- a/recipes-browser/chromium/cef3_280796.bb
+++ b/recipes-browser/chromium/cef3_280796.bb
@@ -9,9 +9,9 @@ SRCREV_cef = "bbad53dfca9f98dddcb31a590410fece0a4f0234"
 SRCREV_egl = "a5b81b7617ba6757802b9b5f8c950034d5f961ec"
 SRCREV_FORMAT = "cef_egl_tools"
 
-SRC_URI = "http://people.linaro.org/~zoltan.kuscsik/chromium-browser/chromium_rev_${PV}.tar.xz \
-           git://github.com/kuscsik/chromiumembedded.git;protocol=https;destsuffix=src/cef;branch=aura;name=cef \
-           git://github.com/kuscsik/ozone-egl.git;protocol=https;destsuffix=src/ui/ozone/platform/egl;branch=master;name=egl \
+SRC_URI = "http://people.linaro.org/~peter.griffin/chromium-browser/chromium_rev_${PV}.tar.xz \
+           git://github.com/linaro-home/chromiumembedded.git;protocol=https;destsuffix=src/cef;branch=aura;name=cef \
+           git://github.com/linaro-home/ozone-egl.git;protocol=https;destsuffix=src/ui/ozone/platform/egl;branch=master;name=egl \
            git://chromium.googlesource.com/chromium/tools/depot_tools.git;protocol=https;destsuffix=depot_tools;branch=master;name=tools \
            file://01_get_svn_version_from_LASTCHANGE.patch \
 	   file://cef-simple \

--- a/recipes-browser/chromium/chromium/chrome-eme
+++ b/recipes-browser/chromium/chromium/chrome-eme
@@ -4,7 +4,7 @@
 #
 #    Tested with EME test site:
 #
-#    http://people.linaro.org/~zoltan.kuscsik/dash.js/samples/dash-if-reference-player/eme.html
+#    http://people.linaro.org/~peter.griffin/dash.js/samples/dash-if-reference-player/eme.html
 
 
 /usr/bin/chromium/chrome --no-sandbox  \

--- a/recipes-browser/chromium/ocdm.inc
+++ b/recipes-browser/chromium/ocdm.inc
@@ -2,7 +2,7 @@ OCDM_GIT_BRANCH="master"
 OCDM_DESTSUFIX="ocdm"
 
 SRC_URI += "${@bb.utils.contains('PACKAGECONFIG', 'use-ocdm', '\
-      git://github.com/kuscsik/linaro-cdm.git;protocol=https;branch=${OCDM_GIT_BRANCH};name=ocdm;destsuffix=${OCDM_DESTSUFIX}\
+      git://github.com/linaro-home/open-content-decryption-module.git;protocol=https;branch=${OCDM_GIT_BRANCH};name=ocdm;destsuffix=${OCDM_DESTSUFIX}\
     ', '', d)}"
 SRCREV_ocdm = "${AUTOREV}"
 DEPENDS_append = " ${@bb.utils.contains('PACKAGECONFIG', 'use-ocdm', 'ocdmi', '', d)} "

--- a/recipes-security/ocdm/ocdmi_git.bb
+++ b/recipes-security/ocdm/ocdmi_git.bb
@@ -7,7 +7,7 @@ DESCRIPTION = "Open Content Decryption Module"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=ea83f8bc099c40bde8c4f2441a6eb40b"
 
-SRC_URI = "git://github.com/kuscsik/linaro-cdmi.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/linaro-home/open-content-decryption-module-cdmi.git;protocol=https;branch=master"
 SRCREV_pn-ocdmi ?= "${AUTOREV}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This removes references in some recipes to Zoltans GitHub account. The various repos have also been updated on linaro-home.