### PR TITLE
chromium_45: fix null pointer dereference in V8 with gcc-6

### DIFF
--- a/recipes-browser/chromium/chromium_45.0.2454.85.bb
+++ b/recipes-browser/chromium/chromium_45.0.2454.85.bb
@@ -192,7 +192,8 @@ CHROMIUM_EXTRA_ARGS ?= " \
 	${@bb.utils.contains('PACKAGECONFIG', 'impl-side-painting', '--enable-gpu-rasterization --enable-impl-side-painting', '', d)} \
 "
 
-GYP_DEFINES += "${ARMFPABI} release_extra_cflags='-Wno-error=unused-local-typedefs' sysroot=''"
+GYP_DEFINES += "${ARMFPABI} release_extra_cflags='-Wno-error=unused-local-typedefs' sysroot='' \
+	${@bb.utils.contains("AVAILTUNES", "mips", "", "release_extra_cflags='-fno-delete-null-pointer-checks'", d)}"
 
 # These are present as their own variables, since they have changed between versions
 # a few times in the past already; making them variables makes it easier to handle that


### PR DESCRIPTION
*** RFC ***

Tested OK on Hikey.

What this patch is currently missing:
1) check if the build uses clang on gcc.
    We always use gcc in our (Linaro) OE builds. Not even sure if building chromium_45 with clang works.
2) this change is applied to wayland builds only. Though it should be applicable to X11 as well.