### PR TITLE
chromium_45: fix null pointer dereference in V8 with gcc-6

### DIFF
--- a/recipes-browser/chromium/chromium_45.0.2454.85.bb
+++ b/recipes-browser/chromium/chromium_45.0.2454.85.bb
@@ -192,7 +192,8 @@ CHROMIUM_EXTRA_ARGS ?= " \
 	${@bb.utils.contains('PACKAGECONFIG', 'impl-side-painting', '--enable-gpu-rasterization --enable-impl-side-painting', '', d)} \
 "
 
-GYP_DEFINES += "${ARMFPABI} release_extra_cflags='-Wno-error=unused-local-typedefs' sysroot=''"
+GYP_DEFINES += "${ARMFPABI} release_extra_cflags='-Wno-error=unused-local-typedefs' sysroot='' \
+	${@bb.utils.contains("AVAILTUNES", "mips", "", "release_extra_cflags='-fno-delete-null-pointer-checks'", d)}"
 
 # These are present as their own variables, since they have changed between versions
 # a few times in the past already; making them variables makes it easier to handle that


### PR DESCRIPTION
This patch prevents "Aw Snap" error when loading a page with JavaScript.

Backported from
https://github.com/OSSystems/meta-browser/commit/179021e6ccf24ffa45856ca508943bb555405a3b

Signed-off-by: Andrey Konovalov <andrey.konovalov@linaro.org>